### PR TITLE
Add `Array.count` function

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,3 +3,4 @@ Closes #[issue number]
 <!-- description of the changes -->
 
 - [ ] add entry to the changelog
+- [ ] update relevant documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- add `Array.count` ([#18](https://github.com/seaofvoices/luau-disk/pull/18))
 - add `Map.fromEntries` ([#17](https://github.com/seaofvoices/luau-disk/pull/17))
 
 ## 0.1.1

--- a/docs/Array.md
+++ b/docs/Array.md
@@ -137,6 +137,19 @@ print(value == result) -- false
 print(value[1] == result[1] and value[2] == result[2]) -- true
 ```
 
+## count
+
+Count the amount of elements that satisfy a predicate.
+
+```lua
+local array = { 'banana', 'cherry', 'date', 'blueberry' },
+local result = count(array, function(value: string)
+    return #value > 5
+end)
+
+-- result is 3
+```
+
 ## deduplicate
 
 Removes duplicate elements from an array.

--- a/src/array/__tests__/count.test.lua
+++ b/src/array/__tests__/count.test.lua
@@ -1,0 +1,54 @@
+local count = require('../count')
+local jestGlobals = require('@pkg/@jsdotlua/jest-globals')
+
+local expect = jestGlobals.expect
+local it = jestGlobals.it
+
+it('returns 0 for an empty array', function()
+    local result = count({})
+
+    expect(result).toEqual(0)
+end)
+
+it('returns array length when no predicate is provided', function()
+    local result = count({ 1, 2, 3, 4, 5 })
+
+    expect(result).toEqual(5)
+end)
+
+it('counts only elements that match the predicate', function()
+    local result = count({ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, function(value: number)
+        return value % 2 == 0
+    end)
+
+    expect(result).toEqual(5)
+end)
+
+it('returns 0 when no elements match the predicate', function()
+    local result = count({ 1, 2, 3, 4, 5 }, function(value: number)
+        return value > 10
+    end)
+
+    expect(result).toEqual(0)
+end)
+
+it('returns array length when predicate always returns true', function()
+    local result = count({ 1, 2, 3, 4, 5 }, function(_value: number)
+        return true
+    end)
+
+    expect(result).toEqual(5)
+end)
+
+it('counts string values with more than 5 characters', function()
+    local result = count(
+        { 'apple', 'banana', 'cherry', 'date', 'elderberry' },
+        function(value: string)
+            return #value > 5
+        end
+    )
+
+    expect(result).toEqual(3)
+end)
+
+return nil

--- a/src/array/count.lua
+++ b/src/array/count.lua
@@ -1,0 +1,17 @@
+local function count<T>(array: { T }, predicate: ((T, number) -> boolean)?): number
+    if predicate == nil then
+        return #array
+    end
+
+    local total = 0
+
+    for i, element in array do
+        if predicate(element, i) then
+            total += 1
+        end
+    end
+
+    return total
+end
+
+return count

--- a/src/init.lua
+++ b/src/init.lua
@@ -12,6 +12,7 @@ local Disk = {
         concat = require('./array/concat'),
         contains = require('./array/contains'),
         copy = require('./array/copy'),
+        count = require('./array/count'),
         deduplicate = require('./array/deduplicate'),
         deduplicateByKey = require('./array/deduplicateByKey'),
         filter = require('./array/filter'),


### PR DESCRIPTION
Count the amount of elements that satisfy a predicate.

```lua
local array = { 'banana', 'cherry', 'date', 'blueberry' },
local result = count(array, function(value: string)
    return #value > 5
end)

-- result is 3
```

- [x] add entry to the changelog
