### PR TITLE
Fix `Array.flatten` to handle depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- fix `Array.flatten` to respect the `depth` parameter when provided ([#34](https://github.com/seaofvoices/luau-disk/pull/34))
 - add `Array.findClosest`, `Array.findClosestBy`, `Array.findClosestIndex` and `Array.findClosestIndexBy` functions ([#33](https://github.com/seaofvoices/luau-disk/pull/33))
 - add `Array.chunks` ([#32](https://github.com/seaofvoices/luau-disk/pull/32))
 - add `Array.repeatSequence` ([#31](https://github.com/seaofvoices/luau-disk/pull/31))

--- a/src/array/__tests__/flatten.test.lua
+++ b/src/array/__tests__/flatten.test.lua
@@ -38,4 +38,22 @@ it('flattens multiple levels of empty arrays', function()
     expect(result).toEqual({})
 end)
 
+it('flattens one level of nested arrays', function()
+    local result = flatten({ 1, { 2, { 3, 4 } :: any }, 5 }, 1)
+    expect(result).toEqual({ 1, 2, { 3, 4 } :: any, 5 })
+end)
+
+it('flattens two levels of nested arrays', function()
+    local deepNestedArray = { 1 :: any, { 2 :: any, { 3, { 4, 5 } :: any, 6 }, 7 }, 8 }
+    local resultWithDepth = flatten(deepNestedArray, 2)
+
+    expect(resultWithDepth).toEqual({ 1, 2, 3, { 4, 5 } :: any, 6, 7, 8 })
+end)
+
+it('returns the original array if depth is 0', function()
+    local value = { { 1 }, { 2 } }
+    local result = flatten(value, 0)
+    expect(result).toBe(value)
+end)
+
 return nil

--- a/src/array/flatten.lua
+++ b/src/array/flatten.lua
@@ -2,7 +2,7 @@ local isArray = require('./isArray')
 
 local function flatten<T>(array: { T | { T } }, depth: number?): { T }
     local actualDepth = if depth == nil then math.huge else depth
-    if actualDepth == 0 then
+    if actualDepth <= 0 then
         return array :: { T }
     end
 
@@ -11,7 +11,7 @@ local function flatten<T>(array: { T | { T } }, depth: number?): { T }
     for _, element in array do
         if isArray(element) then
             local iter: { T } = if actualDepth > 1
-                then flatten(element :: { T })
+                then flatten(element :: { T }, actualDepth - 1)
                 else element :: { T }
             for _, innerElement in iter do
                 table.insert(new, innerElement)


### PR DESCRIPTION
This PR fixes the `Array.flatten` to correctly use the `depth` parameter when provided.

- [x] add entry to the changelog