### PR TITLE
Add `Array.pluck` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- add `Array.pluck` ([#37](https://github.com/seaofvoices/luau-disk/pull/37))
+- migrate the project to use the `luau` file extension ([#36](https://github.com/seaofvoices/luau-disk/pull/36))
 - add `Array.difference` and `Array.differenceSymmetric` ([#35](https://github.com/seaofvoices/luau-disk/pull/35))
 - fix `Array.flatten` to respect the `depth` parameter when provided ([#34](https://github.com/seaofvoices/luau-disk/pull/34))
 - add `Array.findClosest`, `Array.findClosestBy`, `Array.findClosestIndex` and `Array.findClosestIndexBy` functions ([#33](https://github.com/seaofvoices/luau-disk/pull/33))

--- a/docs/Array.md
+++ b/docs/Array.md
@@ -19,6 +19,7 @@ If you are not familiar with this kind of utility functions, don't get overwhelm
 Once you feel comfortable, you may want to take a look at these:
 
 - [flatMap](#flatMap)
+- [pluck](#pluck)
 - [all](#all) and [any](#any)
 - [reduce](#reduce)
 
@@ -603,7 +604,7 @@ end)
 -- squared is {1, 4, 9, 16}
 ```
 
-*Related [flatMap]([#flatMap)*
+*Related [flatMap]([#flatMap), [pluck](#pluck)*
 
 ## maximum
 
@@ -674,6 +675,33 @@ end)
 ```
 
 *Related [filter](#filter)*
+
+## pluck
+
+Builds a new array by reading one key or a sequence of keys from each element (nested lookup).
+
+If a value along the path is `nil`, or if indexing fails (for example the element is not a table), that element is skipped.
+
+```lua
+local rows = {
+    { id = 1, name = 'Ada' },
+    { id = 2, name = 'Grace' },
+}
+local names = Array.pluck(rows, 'name')
+-- names is { 'Ada', 'Grace' }
+
+local nested = {
+    { meta = { score = 10 } },
+    { meta = { score = 20 } },
+}
+local scores = Array.pluck(nested, { 'meta', 'score' })
+-- scores is { 10, 20 }
+
+local same = Array.pluck(rows, {})
+-- same is the same table reference as rows
+```
+
+*Related: [map](#map)*
 
 ## pop
 

--- a/src/array/__tests__/pluck.test.luau
+++ b/src/array/__tests__/pluck.test.luau
@@ -1,0 +1,67 @@
+local jestGlobals = require('@pkg/@jsdotlua/jest-globals')
+local pluck = require('../pluck')
+
+local expect = jestGlobals.expect
+local it = jestGlobals.it
+
+it('plucks a single key from each element', function()
+    local result = pluck({ { id = 1, name = 'a' }, { id = 2, name = 'b' } }, 'name')
+
+    expect(result).toEqual({ 'a', 'b' })
+end)
+
+it('returns an empty array when the input array is empty', function()
+    local result = pluck({}, 'x')
+
+    expect(result).toEqual({})
+end)
+
+it('plucks a nested path when given an array of keys', function()
+    local result = pluck({
+        { outer = { inner = 1 } },
+        { outer = { inner = 2 } },
+    }, { 'outer', 'inner' })
+
+    expect(result).toEqual({ 1, 2 })
+end)
+
+it('returns the same array when the keys list is empty', function()
+    local array = { { a = 1 }, { a = 2 } }
+    local result = pluck(array, {})
+
+    expect(result).toBe(array)
+end)
+
+it('omits elements whose plucked value is nil', function()
+    local result = pluck({
+        { x = 1 :: number?, y = nil :: number? },
+        { y = 2 },
+        { x = 3 },
+    }, 'x')
+
+    expect(result).toEqual({ 1, 3 })
+end)
+
+it('omits elements when a nested key is missing', function()
+    local result = pluck({
+        { outer = { inner = 1 } },
+        { outer = {} :: any },
+        { outer = { inner = 3 } },
+    }, { 'outer', 'inner' })
+
+    expect(result).toEqual({ 1, 3 })
+end)
+
+it('omits elements that are not indexable for the given key', function()
+    local result = pluck({ { n = 1 } :: any, 2, { n = 2 } }, 'n')
+
+    expect(result).toEqual({ 1, 2 })
+end)
+
+it('supports numeric keys on table elements', function()
+    local result = pluck({ { [1] = 'a' }, { [1] = 'b' } }, 1)
+
+    expect(result).toEqual({ 'a', 'b' })
+end)
+
+return nil

--- a/src/array/pluck.luau
+++ b/src/array/pluck.luau
@@ -1,0 +1,39 @@
+local isArray = require('./isArray')
+
+local function pluck<T, U>(array: { T }, key: any | { any }): { U }
+    local length = #array
+
+    local keys = if isArray(key) then key else { key }
+
+    if #keys == 0 then
+        return array :: any
+    end
+
+    local result = table.create(length)
+
+    for _, element in array do
+        local indexed: any = element
+
+        local success = pcall(function()
+            for _, value in keys do
+                indexed = indexed[value]
+
+                if indexed == nil then
+                    break
+                end
+            end
+        end)
+
+        if not success then
+            indexed = nil
+        end
+
+        if indexed ~= nil then
+            table.insert(result, indexed)
+        end
+    end
+
+    return result :: any
+end
+
+return pluck

--- a/src/init.luau
+++ b/src/init.luau
@@ -45,6 +45,7 @@ local Disk = {
         minimum = require('./array/minimum'),
         minimumBy = require('./array/minimumBy'),
         partition = require('./array/partition'),
+        pluck = require('./array/pluck'),
         pop = require('./array/pop'),
         popFirst = require('./array/popFirst'),
         product = require('./array/product'),


### PR DESCRIPTION
Closes #16 

Add `Array.pluck` to map an array to one of its field.

```lua
local rows = {
    { id = 1, name = 'Ada' },
    { id = 2, name = 'Grace' },
}
local names = Array.pluck(rows, 'name')
-- names is { 'Ada', 'Grace' }
```

---

- [x] add entry to the changelog
- [x] update relevant documentation
