### PR TITLE
Update release workflow for OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,13 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   publish-package:
     name: Publish package
     runs-on: ubuntu-latest
+    environment: release
 
     steps:
       - uses: actions/checkout@v4
@@ -28,6 +30,7 @@ jobs:
 
       - name: Enable corepack
         run: corepack enable
+
       - uses: actions/setup-node@v3
         with:
           node-version: "latest"
@@ -37,15 +40,8 @@ jobs:
       - name: Install packages
         run: yarn install --immutable
 
-      - name: Authenticate yarn
-        run: |-
-          yarn config set npmAlwaysAuth true
-          yarn config set npmAuthToken $NPM_AUTH_TOKEN
-        env:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Publish to npm
-        run: yarn npm publish --access public
+        run: yarn npm publish --provenance --access public
 
   create-release:
     needs: publish-package


### PR DESCRIPTION
Try out trusted publishing: https://docs.npmjs.com/trusted-publishers

Hopefully this will ease the management of tokens.